### PR TITLE
Sort usage output and add entry for get

### DIFF
--- a/pws.rb
+++ b/pws.rb
@@ -1027,11 +1027,11 @@ end
 
 def help(code=0, io=STDOUT)
   io.puts "Usage: #{$program_name} ed"
-  io.puts "       #{$program_name} rc"
-  io.puts "       #{$program_name} ls"
   io.puts "       #{$program_name} gitdiff"
-  io.puts "       #{$program_name} update-keyring"
   io.puts "       #{$program_name} help"
+  io.puts "       #{$program_name} ls"
+  io.puts "       #{$program_name} rc"
+  io.puts "       #{$program_name} update-keyring"
   io.puts "Call #{$program_name} <command> --help for additional options/parameters"
   exit(code)
 end

--- a/pws.rb
+++ b/pws.rb
@@ -1027,6 +1027,7 @@ end
 
 def help(code=0, io=STDOUT)
   io.puts "Usage: #{$program_name} ed"
+  io.puts "       #{$program_name} get"
   io.puts "       #{$program_name} gitdiff"
   io.puts "       #{$program_name} help"
   io.puts "       #{$program_name} ls"


### PR DESCRIPTION
Running `pws` without any argument list all the commands. This sort them alphabetically which makes it easier to lookup which commands are available or the exact syntax of a command, it also add an entry for the `get` command.

