### PR TITLE
switch default keyserver to openpgp.org

### DIFF
--- a/pws.rb
+++ b/pws.rb
@@ -918,7 +918,7 @@ class KeyringUpdater
     end
     help(ARGV.options, 1, STDERR) if ARGV.length > 1
     keyserver = ARGV.shift
-    keyserver = 'keys.gnupg.net' unless keyserver
+    keyserver = 'keys.openpgp.org' unless keyserver
 
     groupconfig = GroupConfig.new
     users = groupconfig.get_users()


### PR DESCRIPTION
keys.gnupg.net doesn't have any of the keys we use in the
torproject.org keyring, and generally it seems that keys.openpgp.org
is the new default keyserver one should use from now on.