### PR TITLE
port to Psych 4 included in Ruby 3.1

### DIFF
--- a/pws.rb
+++ b/pws.rb
@@ -267,7 +267,11 @@ class GroupConfig
     elsif FileTest.exists?(CONFIG_FILE)
       t = {}
       begin
-        yaml = YAML::load_file(CONFIG_FILE)
+        if Psych::VERSION > "4.0"
+          yaml = YAML::load_file(CONFIG_FILE, aliases: true)
+        else
+          yaml = YAML::load_file(CONFIG_FILE)
+        end
         yaml["trusted_users"].each do |k,v|
             t[File.expand_path(k)] = v
         end


### PR DESCRIPTION
Since I am not sure when, pwstore just completely fails to start in Debian bookworm:

    anarcat@curie:tor-passwords$ ~/src/pwstore/pws update-keyring
    Unknown alias: weasel

It turns out this is a failure of the YAML module to load our configuration file because of aliases:

    irb(main):004:0> YAML::load_file("/home/anarcat/.pws.yaml")
    /usr/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:430:in `visit_Psych_Nodes_Alias': Unknown alias: weasel (Psych::BadAlias)

The fix seems to be to enable aliases, which is what this project has done:

https://github.com/mperham/sidekiq/issues/5140

Rails seems to have switched to unsafe load, which seems like a bad idea:

https://github.com/rails/rails/pull/42257